### PR TITLE
APIS-4158: fix typo in Gov-Vendor-License-IDs

### DIFF
--- a/app/uk/gov/hmrc/apidocumentation/views/fraudPrevention.scala.html
+++ b/app/uk/gov/hmrc/apidocumentation/views/fraudPrevention.scala.html
@@ -470,7 +470,7 @@
       </ul>
 
       <h4 class="heading-small">For example:</h4>
-      <pre class="code--block">Gov-Vendor-License-ID: my-licensed-software=8D7963490527D33716835EE7C195516D5E562E03B224E9B359836466EE40CDE1</pre>
+      <pre class="code--block">Gov-Vendor-License-IDs: my-licensed-software=8D7963490527D33716835EE7C195516D5E562E03B224E9B359836466EE40CDE1</pre>
       <div class="back_to_top bold-small"><a href="#">Back to top</a></div>
       <hr class="hr--code">
     </div>


### PR DESCRIPTION
We incorrectly have Gov-Vendor-License-ID (in the singular)
in our docs - whereas the header is specified to be
Gov-Vendor-License-IDs.  Whoops