### PR TITLE
APIS-4190 - tell clients not to cache API doc pages

### DIFF
--- a/app/uk/gov/hmrc/apidocumentation/controllers/DocumentationController.scala
+++ b/app/uk/gov/hmrc/apidocumentation/controllers/DocumentationController.scala
@@ -45,7 +45,7 @@ class DocumentationController @Inject()(documentationService: DocumentationServi
                                         val messagesApi: MessagesApi)(implicit val appConfig: ApplicationConfig, val ec: ExecutionContext)
     extends FrontendController with I18nSupport {
 
-  private lazy val cacheControlHeaders = "cache-control" -> s"public, max-age=${documentationService.defaultExpiration.toSeconds}"
+  private lazy val cacheControlHeaders = "cache-control" -> "no-cache,no-store,max-age=0"
   private val homeCrumb = Crumb("Home", routes.DocumentationController.indexPage().url)
   private val apiDocCrumb = Crumb("API Documentation", routes.DocumentationController.apiIndexPage(None, None, None).url)
   private val usingTheHubCrumb = Crumb("Using the Developer Hub", routes.DocumentationController.usingTheHubPage().url)

--- a/test/unit/uk/gov/hmrc/apidocumentation/controllers/DocumentationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/apidocumentation/controllers/DocumentationControllerSpec.scala
@@ -539,6 +539,16 @@ class DocumentationControllerSpec extends UnitSpec with MockitoSugar with ScalaF
 
       verifyErrorPageRendered(result, expectedStatus = INTERNAL_SERVER_ERROR, expectedError = "Sorry, we’re experiencing technical difficulties")
     }
+
+    "tell clients not to cache the page" in new Setup {
+      theUserIsLoggedIn()
+      theDocumentationServiceWillReturnAnApiDefinition(Some(extendedApiDefinition(serviceName, "1.0")))
+      theDocumentationServiceWillFetchRaml(mockRamlAndSchemas)
+
+      val result = underTest.renderApiDocumentation(serviceName, "1.0", Option(true))(request)
+
+      result.header.headers.get("Cache-Control") shouldBe Some("no-cache,no-store,max-age=0")
+    }
   }
 
   "preview docs" should {


### PR DESCRIPTION
Supports dynamic docs, i.e. private trial view between logged out and
logged in + whitelisted