### PR TITLE
Added link on home page to fraud prevention page

### DIFF
--- a/app/uk/gov/hmrc/apidocumentation/views/index.scala.html
+++ b/app/uk/gov/hmrc/apidocumentation/views/index.scala.html
@@ -64,6 +64,7 @@
                     <li><a href="@controllers.routes.DocumentationController.authorisationPage()">Authorisation</a></li>
                     <li><a href="@controllers.routes.DocumentationController.tutorialsPage()">Tutorials</a></li>
                     <li><a href="@controllers.routes.DocumentationController.termsOfUsePage()">Terms of use</a></li>
+                    <li><a href="@controllers.routes.DocumentationController.fraudPreventionPage()">Fraud prevention</a></li>
                 </ul>
             </section>
         </div>


### PR DESCRIPTION
There are no unit or acceptance tests for home page links so I haven't changed any tests.