### PR TITLE
APIS-4377 - Added https://www.googletagmanager.com to  CSP

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -80,7 +80,7 @@ platform {
   }
 }
 
-play.filters.headers.contentSecurityPolicy= "default-src 'unsafe-inline' 'self' localhost:9032 data: https://www.google-analytics.com; script-src 'unsafe-inline' 'self' localhost:9032 https://www.google-analytics.com data: https://www.googletagmanager.com https://tagmanager.google.com; font-src 'self' data: https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com"
+play.filters.headers.contentSecurityPolicy = "default-src 'unsafe-inline' 'self' localhost:9032 data: https://www.google-analytics.com https://www.googletagmanager.com; script-src 'unsafe-inline' 'self' localhost:9032 https://www.google-analytics.com data: https://www.googletagmanager.com https://tagmanager.google.com; font-src 'self' data: https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com"
 wiremock-port = 11111
 wiremock-port = ${?WIREMOCK_PORT}
 


### PR DESCRIPTION
Added https://www.googletagmanager.com to  CSP to the default-src directive. Required by GTM when sending small blocks of data to GTM. This causes some of the AT's to fail.