### PR TITLE
APIS-4632 - Fixed Add Application links after update to App Check journey

### DIFF
--- a/app/uk/gov/hmrc/apidocumentation/views/index.scala.html
+++ b/app/uk/gov/hmrc/apidocumentation/views/index.scala.html
@@ -82,7 +82,6 @@
             <section class="section section--branded">
                 <h2>Integrate</h2>
                 <ul>
-                    <li><a href="@applicationConfig.developerFrontendUrl/developer/applications/add">Add application</a></li>
                     <li><a href="@applicationConfig.developerFrontendUrl/developer/applications">Manage applications</a></li>
                     <li><a href="@controllers.routes.DocumentationController.testingPage()">Testing in the sandbox</a></li>
                     <li><a href="@applicationConfig.developerFrontendUrl/api-test-user">Create a test user</a></li>

--- a/app/uk/gov/hmrc/apidocumentation/views/testing.scala.html
+++ b/app/uk/gov/hmrc/apidocumentation/views/testing.scala.html
@@ -42,7 +42,7 @@
         <a href="https://www.gov.uk/government/publications/basic-guide-for-software-developers">Basic guide for software developers</a>.
     </p>
     <h3 class="heading-medium">1. Add an application</h3>
-    <p><a href="https://developer.service.hmrc.gov.uk/developer/applications/add">Add a sandbox application</a> to use for testing.</p>
+    <p><a href="https://developer.service.hmrc.gov.uk/developer/applications/add/sandbox">Add a sandbox application</a> to use for testing.</p>
     <p>Sandbox applications that have not made an API call for 12 months will be deleted.</p>
     <h3 class="heading-medium">2. Subscribe to APIs</h3>
     <p>You must subscribe to APIs before your application can access them. Subscribe on the manage API subscriptions page.</p>


### PR DESCRIPTION
- Removed Add Application link from the index page
- Fixed Add Sandbox Application link on the testing page.