### PR TITLE
APIS-4777 - Fixed support for non-standard http status code.

### DIFF
--- a/app/uk/gov/hmrc/apidocumentation/views/helpers/Helpers.scala
+++ b/app/uk/gov/hmrc/apidocumentation/views/helpers/Helpers.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.apidocumentation.views.helpers
 
-import akka.http.scaladsl.model.StatusCode
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import org.raml.v2.api.model.v10.bodies.Response
 import org.raml.v2.api.model.v10.common.Annotable
 import org.raml.v2.api.model.v10.datamodel._
@@ -328,7 +328,13 @@ object HttpStatus {
   def apply(statusCode: String): String = apply(statusCode.toInt)
 
   def apply(statusCode: Int): String = {
-    val responseStatus = StatusCode.int2StatusCode(statusCode)
+
+    val responseStatus: StatusCode = try {
+       StatusCode.int2StatusCode(statusCode)
+    } catch {
+      case _ : RuntimeException => StatusCodes.custom(statusCode,"non-standard", "" )
+    }
+
     s"$statusCode (${responseStatus.reason})"
   }
 }

--- a/test/uk/gov/hmrc/apidocumentation/views/helpers/HelpersSpec.scala
+++ b/test/uk/gov/hmrc/apidocumentation/views/helpers/HelpersSpec.scala
@@ -971,5 +971,9 @@ class HelpersSpec extends WordSpec with Matchers {
     "provide an enriched string for the status code" in {
       HttpStatus(200) shouldBe "200 (OK)"
     }
+
+    "parse invalid status code like 498" in {
+      HttpStatus(498) shouldBe "498 (non-standard)"
+    }
   }
 }


### PR DESCRIPTION
 - Where producer teams define non-standard status codes in RAML the play 2.6 version rejected them. It now parses them.