### PR TITLE
APIS-4844 - Make logic for preferring Subordinate over Principal consistent.

### DIFF
--- a/app/uk/gov/hmrc/apidocumentation/models/Documentation.scala
+++ b/app/uk/gov/hmrc/apidocumentation/models/Documentation.scala
@@ -250,15 +250,9 @@ case class ExtendedAPIVersion(version: String,
                               productionAvailability: Option[APIAvailability],
                               sandboxAvailability: Option[APIAvailability]) {
   def visibility: Option[VersionVisibility] = {
-    def highestAccess(production: APIAvailability, sandbox: APIAvailability) = {
-      if(production.access.`type` == APIAccessType.PUBLIC) APIAccessType.PUBLIC
-      else sandbox.access.`type`
-    }
+
     def isLoggedIn(production: APIAvailability, sandbox: APIAvailability) = {
       production.loggedIn || sandbox.loggedIn
-    }
-    def isAuthorised(production: APIAvailability, sandbox: APIAvailability) = {
-      production.authorised || sandbox.authorised
     }
 
     def isInTrial(production: APIAvailability, sandbox: APIAvailability) = (production.access.isTrial, sandbox.access.isTrial) match {
@@ -270,7 +264,7 @@ case class ExtendedAPIVersion(version: String,
       case (Some(prod), None) => Some(VersionVisibility(prod.access.`type`, prod.loggedIn, prod.authorised, prod.access.isTrial))
       case (None, Some(sandbox)) => Some(VersionVisibility(sandbox.access.`type`, sandbox.loggedIn, sandbox.authorised, sandbox.access.isTrial))
       case (Some(prod), Some(sandbox)) =>
-        Some(VersionVisibility(highestAccess(prod, sandbox), isLoggedIn(prod, sandbox), isAuthorised(prod, sandbox), isInTrial(prod, sandbox)))
+        Some(VersionVisibility(sandbox.access.`type`, isLoggedIn(prod, sandbox), sandbox.authorised, isInTrial(prod, sandbox)))
       case _ => None
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -144,6 +144,6 @@ lazy val allDeps = compile ++ test
 
 // Coverage configuration
 // TODO ebridge - Fix and set back to 85
-coverageMinimum := 60
+coverageMinimum := 64
 coverageFailOnMinimum := true
 coverageExcludedPackages := "<empty>;com.kenshoo.play.metrics.*;.*definition.*;prod.*;uk.gov.hmrc.apidocumentation.config.*;.*javascript;testOnlyDoNotUseInAppConf.*;app.*;config.*"

--- a/test/uk/gov/hmrc/apidocumentation/controllers/CommonControllerBaseSpec.scala
+++ b/test/uk/gov/hmrc/apidocumentation/controllers/CommonControllerBaseSpec.scala
@@ -77,6 +77,25 @@ class CommonControllerBaseSpec
       ))
   }
 
+  def extendedApiDefinitionWithNoAPIAvailability(serviceName: String, version: String): ExtendedAPIDefinition = {
+    ExtendedAPIDefinition(serviceName, "Hello World", "Say Hello World", "hello", requiresTrust = false, isTestSupport = false,
+      Seq(
+        ExtendedAPIVersion(version, APIStatus.STABLE, Seq(Endpoint(endpointName, "/world", HttpMethod.GET, None)), None, None)
+      ))
+  }
+
+  def extendedApiDefinitionWithPrincipalAndSubordinateAPIAvailability(
+      serviceName: String,
+      version: String,
+      principalApiAvailability: Option[APIAvailability],
+      subordinateApiAvailability: Option[APIAvailability]): ExtendedAPIDefinition = {
+    ExtendedAPIDefinition(serviceName, "Hello World", "Say Hello World", "hello", requiresTrust = false, isTestSupport = false,
+      Seq(
+        ExtendedAPIVersion(version, APIStatus.STABLE, Seq(Endpoint(endpointName, "/world", HttpMethod.GET, None)),
+          principalApiAvailability, subordinateApiAvailability)
+      ))
+  }
+
   def extendedApiDefinitionWithRetiredVersion(serviceName: String, retiredVersion: String, nonRetiredVersion: String) = {
     ExtendedAPIDefinition(serviceName, "Hello World", "Say Hello World", "hello", requiresTrust = false, isTestSupport = false,
       Seq(

--- a/test/uk/gov/hmrc/apidocumentation/mocks/services/ApiDocumentationServiceMock.scala
+++ b/test/uk/gov/hmrc/apidocumentation/mocks/services/ApiDocumentationServiceMock.scala
@@ -20,7 +20,9 @@ import org.mockito.Matchers._
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.apidocumentation.models._
+import uk.gov.hmrc.apidocumentation.models.apispecification.ApiSpecification
 import uk.gov.hmrc.apidocumentation.services.DocumentationService
+import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future.{failed, successful}
 
@@ -34,4 +36,9 @@ trait ApiDocumentationServiceMock extends MockitoSugar {
   def theDocumentationServiceWillFailWhenFetchingRaml(exception: Throwable) = {
     when(documentationService.fetchRAML(any(), any(), any())).thenReturn(failed(exception))
   }
+
+  def theDocumentationServiceWillFetchApiSpecification(apiSpecification: ApiSpecification)(implicit hc: HeaderCarrier) = {
+    when(documentationService.fetchApiSpecification(any(), any(), any())(any())).thenReturn(successful(apiSpecification))
+  }
+
 }

--- a/test/uk/gov/hmrc/apidocumentation/mocks/services/NavigationServiceMock.scala
+++ b/test/uk/gov/hmrc/apidocumentation/mocks/services/NavigationServiceMock.scala
@@ -31,6 +31,7 @@ trait NavigationServiceMock extends MockitoSugar {
   when(navigationService.headerNavigation()(any[HeaderCarrier])).thenReturn(successful(Seq(navLink)))
   when(navigationService.sidebarNavigation()).thenReturn(Seq(sidebarLink))
   when(navigationService.apiSidebarNavigation(any(), any(), any())).thenReturn(Seq(sidebarLink))
+  when(navigationService.apiSidebarNavigation2(any(), any(), any())).thenReturn(Seq(sidebarLink))
 }
 
 object NavigationServiceMock {

--- a/test/uk/gov/hmrc/apidocumentation/models/DocumentationSpec.scala
+++ b/test/uk/gov/hmrc/apidocumentation/models/DocumentationSpec.scala
@@ -395,7 +395,5 @@ class DocumentationSpec extends UnitSpec {
     def anEndpoint(uriPattern: String, parameters: Option[Seq[Parameter]]) = {
       Endpoint("Get Today's Date", uriPattern, HttpMethod.GET, parameters)
     }
-
   }
-
 }


### PR DESCRIPTION
Changed renderApiDocumentation endpoint in ApiDocumentationController (to render a specific API version page) to prefer Subordinate APIAvailability over Production Availability.
This brings the logic in line with the apiIndexPage endpoint which renders the make docs list page.