### PR TITLE
APIS-5282: Remove GA cookies to not be sent when cookie consent is rejected

### DIFF
--- a/app/assets/javascripts/cookie-banner.js
+++ b/app/assets/javascripts/cookie-banner.js
@@ -1,4 +1,0 @@
-// APIS-1199-cookie-banner
-$(function() {
-    $('#global-header').insertAfter( $('#global-cookie-message') );
-});

--- a/app/assets/javascripts/googleTagManager.js
+++ b/app/assets/javascripts/googleTagManager.js
@@ -1,8 +1,0 @@
-(function(w,d,s,l,i){
-        w[l]=w[l]||[];
-        w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
-        var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-        j.async=true;
-        j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;
-        f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-TSFTCWZ');

--- a/app/uk/gov/hmrc/apidocumentation/views/IndexView.scala.html
+++ b/app/uk/gov/hmrc/apidocumentation/views/IndexView.scala.html
@@ -19,9 +19,9 @@
 @import uk.gov.hmrc.apidocumentation.models._
 @import uk.gov.hmrc.apidocumentation.views.html.templates.LayoutHomePage
 
-@this(layoutHomePage: LayoutHomePage, applicationConfig: ApplicationConfig)
+@this(layoutHomePage: LayoutHomePage)
 
-@(pageTitle: String, navLinks: Seq[NavLink])(implicit messagesProvider: MessagesProvider, request: play.api.mvc.Request[Any])
+@(pageTitle: String, navLinks: Seq[NavLink])(implicit applicationConfig: ApplicationConfig, messagesProvider: MessagesProvider, request: play.api.mvc.Request[Any])
 
 @layoutHomePage(
     headerNavLinks = Some(partials.headerNavLinks(navLinks)),

--- a/app/uk/gov/hmrc/apidocumentation/views/include/main.scala.html
+++ b/app/uk/gov/hmrc/apidocumentation/views/include/main.scala.html
@@ -96,9 +96,6 @@
 }
 
 @bodyContent = {
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSFTCWZ"
-                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-
     @if(fullWidthBanner.isDefined) {
         <div class="centered-content">
             @banner

--- a/app/uk/gov/hmrc/apidocumentation/views/templates/GovUkWrapper.scala.html
+++ b/app/uk/gov/hmrc/apidocumentation/views/templates/GovUkWrapper.scala.html
@@ -76,9 +76,6 @@
 }
 
 @mainContentDefault = {
-    <noscript>
-        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSFTCWZ" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
     <div class="govuk-width-container">
         <div class="govuk-grid-row">
             <div id="navContent" class="govuk-grid-column-one-quarter">

--- a/app/uk/gov/hmrc/apidocumentation/views/templates/LayoutHomePage.scala.html
+++ b/app/uk/gov/hmrc/apidocumentation/views/templates/LayoutHomePage.scala.html
@@ -35,7 +35,7 @@
   navLinks: Seq[NavLink] = Seq.empty,
   navTitle: Option[String] = None,
   headerNavLinks: Option[Html] = None
-)(contentBlock: Html)(implicit request: Request[_], messages: Messages)
+)(contentBlock: Html)(implicit applicationConfig: ApplicationConfig, request: Request[_], messages: Messages)
 
 @head = {
     <link href='@controllers.routes.Assets.versioned("css/main.css")' media="screen" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
- Remove old cookie banner
- Remove google tag manager script to stop tracking without permission
- Remove outdated no script tracking tags in the views
- The home page of docs-fe uses its own view ---> Fix the bug and implement cookie banner to show on this page