### PR TITLE
Revert "CTCP-308 Added ctc traders tis guide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Frontend for API documentation - part of the Developer Hub
 
 2. Install chrome driver if you have not done already .
 
-   2a. If using MAC OS this can be done using command ```brew install chromedriver```
-       You might have to un-quarantine the chromedriver ```xattr -d com.apple.quarantine /usr/local/bin/chromedriver```
+   2a. If using MAC OS this can be done using command ```brew cask install chromedriver```
    
    2b. If not using MAC chromedriver can be downloaded from **https://chromedriver.storage.googleapis.com/index.html?path=2.29/**
    

--- a/resources/categories.json
+++ b/resources/categories.json
@@ -68,6 +68,5 @@
   "Customs Declarations end-to-end service guide": ["CUSTOMS"],
   "Interest Restriction Return (IRR) service guide": ["CORPORATION_TAX"],
   "CTC Guarantee Balance service guide": ["CUSTOMS"],
-  "CTC Guarantee Balance testing guide": ["CUSTOMS"],
-  "CTC Traders Phase 5 Technical Interface Specification": ["CUSTOMS"]
+  "CTC Guarantee Balance testing guide": ["CUSTOMS"]
 }

--- a/resources/service_guides.json
+++ b/resources/service_guides.json
@@ -42,9 +42,5 @@
   {
     "name": "CTC Guarantee Balance testing guide",
     "context": "/guides/ctc-guarantee-balance-testing-guide/"
-  },
-  {
-    "name": "CTC Traders Phase 5 Technical Interface Specification",
-    "context": "/guides/ctc-traders-phase5-tis/"
   }
 ]


### PR DESCRIPTION
Reverts hmrc/api-documentation-frontend#352

Reverting this as its not ready for prod and needs to be accessed directly as oppose to via Docs FE which gets released to prod regularly.