### PR TITLE
Rename CTC document titles

### DIFF
--- a/resources/categories.json
+++ b/resources/categories.json
@@ -63,7 +63,7 @@
   "Self Assessment end-to-end service guide": ["SELF_ASSESSMENT"],
   "Safety and security import declarations service guide": ["CUSTOMS"],
   "CTC Traders phase 4 service guide": ["CUSTOMS"],
-  "Common Transit Convention Traders testing guide": ["CUSTOMS"],
+  "CTC Traders phase 4 testing guide": ["CUSTOMS"],
   "Goods Vehicle Movements service guide": ["CUSTOMS"],
   "Customs Declarations end-to-end service guide": ["CUSTOMS"],
   "Interest Restriction Return (IRR) service guide": ["CORPORATION_TAX"],

--- a/resources/roadmap.json
+++ b/resources/roadmap.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Common Transit Convention Traders Roadmap",
+    "name": "CTC Traders roadmap",
     "context": "/roadmaps/common-transit-convention-traders-roadmap/",
     "categories": [
       "CUSTOMS"

--- a/resources/service_guides.json
+++ b/resources/service_guides.json
@@ -20,8 +20,8 @@
     "context": "/guides/ctc-traders-phase4-service-guide/"
   },
   {
-    "name": "Common Transit Convention Traders testing guide",
-    "context": "/guides/common-transit-convention-traders-testing-guide/"
+    "name": "CTC Traders phase 4 testing guide",
+    "context": "/guides/ctc-traders-phase4-testing-guide/"
   },
   {
     "name": "Goods Vehicle Movements service guide",


### PR DESCRIPTION
Renamed CTC document titles as per CTCP-284 and replaced CTC P4 testing guide with new service name/url as per CTCP-192